### PR TITLE
Results filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,23 @@ if summary.warningsCount > maxWarningsCount {
   fail("There are more than \(maxWarningsCount) warnings"
 }
 ```
+
+## Filtering results
+Don't show warnings:
+
+```swift
+let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: reportTestJSON), dsl: dsl, resultsFilter: { result in
+    return result.category != .warning
+})
+summary.report()
+```
+
+Filter out any error or warning for a specific path:
+
+```swift
+let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: warningsJSON), dsl: dsl, resultsFilter: { result in
+    guard let file = result.file else { return true }
+    return !file.contains("Sources/DangerXCodeSummary/")
+})
+summary.report()
+```

--- a/Sources/DangerXCodeSummary/CompilerMessageParser.swift
+++ b/Sources/DangerXCodeSummary/CompilerMessageParser.swift
@@ -9,7 +9,7 @@ struct CompilerMessageParser {
         case invalidJSON
     }
     
-    static func parseMessage(messageJSON: [String:Any]) throws -> Result {
+    static func parseMessage(messageJSON: [String:Any], category: Result.Category) throws -> Result {
         guard let reason: String = messageJSON[Keys.reason],
             let filePath: String = messageJSON[Keys.filePath] else {
                 throw ParsingErrors.invalidJSON
@@ -17,6 +17,6 @@ struct CompilerMessageParser {
         
         let (file, line) = try FilePathParser.parseFilePath(filePath: filePath)
         
-        return Result(message: reason, file: file, line: line)
+        return Result(message: reason, file: file, line: line, category: category)
     }
 }

--- a/Sources/DangerXCodeSummary/MissingFileErrorParser.swift
+++ b/Sources/DangerXCodeSummary/MissingFileErrorParser.swift
@@ -9,6 +9,6 @@ struct MissingFileErrorParser {
         let reason = missingFileErrorJSON[Keys.reason] ?? ""
         let filePath = missingFileErrorJSON[Keys.filePath] ?? ""
         
-        return Result(message: "**\(reason)**: \(filePath)")
+        return Result(message: "**\(reason)**: \(filePath)", category: .error)
     }
 }

--- a/Sources/DangerXCodeSummary/Result.swift
+++ b/Sources/DangerXCodeSummary/Result.swift
@@ -1,20 +1,28 @@
 
-struct Result: Equatable {
-    let message: String
-    let file: String?
-    let line: Int?
+public struct Result: Equatable {
+    public enum Category {
+        case warning, error, message
+    }
+
+    public let message: String
+    public let file: String?
+    public let line: Int?
+    public let category: Category
     
-    init(message: String) {
+    init(message: String, category: Category) {
         self.message = message
         self.file = nil
         self.line = nil
+        self.category = category
     }
     
     init(message: String,
          file: String,
-         line: Int?) {
+         line: Int?,
+         category: Category) {
         self.message = message
         self.file = file
         self.line = line
+        self.category = category
     }
 }

--- a/Sources/DangerXCodeSummary/SymbolsErrorsParser.swift
+++ b/Sources/DangerXCodeSummary/SymbolsErrorsParser.swift
@@ -17,7 +17,7 @@ struct SymbolsErrorsParser {
         "> Symbol: \(symbol) <br />" +
         "> Referenced from: \(reference)"
         
-        return Result(message: resultText)
+        return Result(message: resultText, category: .error)
     }
     
     static func parseDuplicatedSymbols(json: [String:Any]) -> Result {
@@ -27,6 +27,6 @@ struct SymbolsErrorsParser {
         let resultText = "\(message) <br />" +
         "> \(paths.map { $0.split(separator: "/").last! }.joined(separator: "<br />")))"
         
-        return Result(message: resultText)
+        return Result(message: resultText, category: .error)
     }
 }

--- a/Sources/DangerXCodeSummary/TestFailuresParser.swift
+++ b/Sources/DangerXCodeSummary/TestFailuresParser.swift
@@ -14,7 +14,7 @@ struct TestFailuresParser {
         let message = "**\(testSuite): \(testCase)**<br />\(reason.deletingSuffix(" -").deletingSuffix(" - "))"
         let (file, line) = try FilePathParser.parseFilePath(filePath: filePath)
         
-        return Result(message: message, file: file, line: line)
+        return Result(message: message, file: file, line: line, category: .error)
     }
 }
 

--- a/Tests/DangerXCodeSummaryTests/CompilerMessageParserTests.swift
+++ b/Tests/DangerXCodeSummaryTests/CompilerMessageParserTests.swift
@@ -6,10 +6,11 @@ final class CompilerMessageParserTests: XCTestCase {
         let json = JSONFile.jsonObject(fromString: compilerErrorJSON)
         let errors = json["compile_errors"] as! [[String:Any]]
         
-        let parsedMessage = try! CompilerMessageParser.parseMessage(messageJSON: errors[0])
+        let parsedMessage = try! CompilerMessageParser.parseMessage(messageJSON: errors[0], category: .error)
         
         XCTAssertEqual(parsedMessage.message, "use of undeclared identifier 'trololo'")
         XCTAssertEqual(parsedMessage.file, "/Users/musalj/code/OSS/ObjectiveSugar/Classes/NSNumber+ObjectiveSugar.m")
         XCTAssertEqual(parsedMessage.line, 26)
+        XCTAssertEqual(parsedMessage.category, .error)
     }
 }

--- a/Tests/DangerXCodeSummaryTests/MissingFileErrorParserTests.swift
+++ b/Tests/DangerXCodeSummaryTests/MissingFileErrorParserTests.swift
@@ -6,6 +6,6 @@ final class MissingFileErrorParserTests: XCTestCase {
         let json = ["reason": "File not found",
                     "file_path": "/franco/Test.swift"]
         
-        XCTAssertEqual(MissingFileErrorParser.parseMissingFileError(missingFileErrorJSON: json), Result(message: "**File not found**: /franco/Test.swift"))
+        XCTAssertEqual(MissingFileErrorParser.parseMissingFileError(missingFileErrorJSON: json), Result(message: "**File not found**: /franco/Test.swift", category: .error))
     }
 }

--- a/Tests/DangerXCodeSummaryTests/XCodeSummaryTests.swift
+++ b/Tests/DangerXCodeSummaryTests/XCodeSummaryTests.swift
@@ -22,9 +22,9 @@ final class XCodeSummaryTests: XCTestCase {
         let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: warningsJSON), dsl: dsl)
         
         XCTAssertEqual(summary.warnings, [
-            Result(message: "Capabilities that require entitlements from \"SampleProject/SampleProject.entitlements\" may not function in the Simulator because none of the valid provisioning profiles allowed the specified entitlements: com.apple.security.application-groups, keychain-access-groups."),
-            Result(message: "Linker asked to preserve internal global: '__block_descriptor_tmp'"),
-            Result(message: "Test", file: "/Users/franco/Projects/DangerXCodeSummary/Sources/DangerXCodeSummary/XCodeSummary.swift", line: 26)
+            Result(message: "Capabilities that require entitlements from \"SampleProject/SampleProject.entitlements\" may not function in the Simulator because none of the valid provisioning profiles allowed the specified entitlements: com.apple.security.application-groups, keychain-access-groups.", category: .warning),
+            Result(message: "Linker asked to preserve internal global: '__block_descriptor_tmp'", category: .warning),
+            Result(message: "Test", file: "/Users/franco/Projects/DangerXCodeSummary/Sources/DangerXCodeSummary/XCodeSummary.swift", line: 26, category: .warning)
         ])
         
         XCTAssertEqual(summary.warningsCount, 3)
@@ -33,12 +33,12 @@ final class XCodeSummaryTests: XCTestCase {
     func testItParsesErrorsCorrectly() {
         let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: errorsJSON), dsl: dsl)
         
-        XCTAssertEqual(summary.errors[0], Result(message: "error: Build input file cannot be found: '/Users/franco/Projects/DangerXCodeSummary/Test.swift'"))
-        XCTAssertEqual(summary.errors[1], Result(message: "use of undeclared identifier 'trololo'", file: "/Users/musalj/code/OSS/ObjectiveSugar/Classes/NSNumber+ObjectiveSugar.m", line: 26))
-        XCTAssertEqual(summary.errors[2], Result(message: "returning 'float' from a function with incompatible result type 'NSNumber *'", file: "/Users/musalj/code/OSS/ObjectiveSugar/Classes/NSNumber+ObjectiveSugar.m", line: 47))
-        XCTAssertTrue(summary.errors.contains(Result(message: "**BlackJack_iOS_Failing_Tests.FailingCardTestCase: testAllRankCases**<br />XCTAssertEqual failed: (\"13\") is not equal to (\"12\")", file: "/BlackJack/Framework/Tests/Failing/FailingCardTests.swift", line: 19)))
-        XCTAssertTrue(summary.errors.contains(Result(message: "**BlackJack_iOS_Failing_Tests.FailingCardTestCase: testAllSuitCases**<br />XCTAssertEqual failed: (\"4\") is not equal to (\"3\")", file: "/BlackJack/Framework/Tests/Failing/FailingCardTests.swift", line: 27)))
-        XCTAssertTrue(summary.errors.contains(Result(message: "**BlackJack_Tests.DeckTestCase: testStandardDeck**<br />XCTAssertEqual failed: (\"52\") is not equal to (\"51\")", file: "/BlackJack/Framework/Tests/DeckTests.swift", line: 49)))
+        XCTAssertEqual(summary.errors[0], Result(message: "error: Build input file cannot be found: '/Users/franco/Projects/DangerXCodeSummary/Test.swift'", category: .error))
+        XCTAssertEqual(summary.errors[1], Result(message: "use of undeclared identifier 'trololo'", file: "/Users/musalj/code/OSS/ObjectiveSugar/Classes/NSNumber+ObjectiveSugar.m", line: 26, category: .error))
+        XCTAssertEqual(summary.errors[2], Result(message: "returning 'float' from a function with incompatible result type 'NSNumber *'", file: "/Users/musalj/code/OSS/ObjectiveSugar/Classes/NSNumber+ObjectiveSugar.m", line: 47, category: .error))
+        XCTAssertTrue(summary.errors.contains(Result(message: "**BlackJack_iOS_Failing_Tests.FailingCardTestCase: testAllRankCases**<br />XCTAssertEqual failed: (\"13\") is not equal to (\"12\")", file: "/BlackJack/Framework/Tests/Failing/FailingCardTests.swift", line: 19, category: .error)))
+        XCTAssertTrue(summary.errors.contains(Result(message: "**BlackJack_iOS_Failing_Tests.FailingCardTestCase: testAllSuitCases**<br />XCTAssertEqual failed: (\"4\") is not equal to (\"3\")", file: "/BlackJack/Framework/Tests/Failing/FailingCardTests.swift", line: 27, category: .error)))
+        XCTAssertTrue(summary.errors.contains(Result(message: "**BlackJack_Tests.DeckTestCase: testStandardDeck**<br />XCTAssertEqual failed: (\"52\") is not equal to (\"51\")", file: "/BlackJack/Framework/Tests/DeckTests.swift", line: 49, category: .error)))
         XCTAssertEqual(summary.errorsCount, 7)
     }
     
@@ -46,8 +46,8 @@ final class XCodeSummaryTests: XCTestCase {
         let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: testsSummaryJSON), dsl: dsl)
         
         XCTAssertEqual(summary.messages, [
-            Result(message: "Executed 3 tests, with 0 failures (0 unexpected) in 0.039 (0.055) seconds"),
-            Result(message: "Executed 14 tests, with 0 failures (0 unexpected) in 0.015 (0.025) seconds")
+            Result(message: "Executed 3 tests, with 0 failures (0 unexpected) in 0.039 (0.055) seconds", category: .message),
+            Result(message: "Executed 14 tests, with 0 failures (0 unexpected) in 0.015 (0.025) seconds", category: .message)
         ])
     }
     

--- a/Tests/DangerXCodeSummaryTests/XCodeSummaryTests.swift
+++ b/Tests/DangerXCodeSummaryTests/XCodeSummaryTests.swift
@@ -61,4 +61,53 @@ final class XCodeSummaryTests: XCTestCase {
         
         try? FileManager.default.removeItem(atPath: "dsl.json")
     }
+
+    func testItFiltersWarnings() {
+        let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: reportTestJSON), dsl: dsl, resultsFilter: { result in
+            return result.category != .warning
+        })
+        summary.report()
+        XCTAssertEqual(dsl.warnings.count, 0)
+        XCTAssertEqual(dsl.fails.count, 1)
+        XCTAssertEqual(dsl.messages.count, 2)
+
+        try? FileManager.default.removeItem(atPath: "dsl.json")
+    }
+
+    func testItFiltersMessages() {
+        let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: reportTestJSON), dsl: dsl, resultsFilter: { result in
+            return result.category != .message
+        })
+        summary.report()
+        XCTAssertEqual(dsl.warnings.count, 1)
+        XCTAssertEqual(dsl.fails.count, 1)
+        XCTAssertEqual(dsl.messages.count, 0)
+
+        try? FileManager.default.removeItem(atPath: "dsl.json")
+    }
+
+    func testItFiltersErrors() {
+        let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: reportTestJSON), dsl: dsl, resultsFilter: { result in
+            return result.category != .error
+        })
+        summary.report()
+        XCTAssertEqual(dsl.warnings.count, 1)
+        XCTAssertEqual(dsl.fails.count, 0)
+        XCTAssertEqual(dsl.messages.count, 2)
+
+        try? FileManager.default.removeItem(atPath: "dsl.json")
+    }
+
+    func testItFiltersFilePaths() {
+        let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: warningsJSON), dsl: dsl, resultsFilter: { result in
+            guard let file = result.file else { return true }
+            return !file.contains("Sources/DangerXCodeSummary/")
+        })
+        summary.report()
+        XCTAssertEqual(dsl.warnings.count, 2)
+        XCTAssertEqual(dsl.fails.count, 0)
+        XCTAssertEqual(dsl.messages.count, 0)
+
+        try? FileManager.default.removeItem(atPath: "dsl.json")
+    }
 }


### PR DESCRIPTION
Just like the original Ruby version of this project, this PR implements results filtering. This allows to ignore specific type of results or filtering out results based on the message or file path.

### Examples
Don't show warnings:

```swift
let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: reportTestJSON), dsl: dsl, resultsFilter: { result in
    return result.category != .warning
})
summary.report()
```

Filter out any error or warning for a specific path:

```swift
let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: warningsJSON), dsl: dsl, resultsFilter: { result in
    guard let file = result.file else { return true }
    return !file.contains("Sources/DangerXCodeSummary/")
})
summary.report()
```

### Notes
- I've had to make the `Result` struct public for this
- I've also updated the readme so it's clear for the users how this works
- A changelog was missing, so I did not add anything there