### PR TITLE
Filter out duplicate messages, warnings, and errors

### DIFF
--- a/Sources/DangerXCodeSummary/Result.swift
+++ b/Sources/DangerXCodeSummary/Result.swift
@@ -1,5 +1,5 @@
 
-public struct Result: Equatable {
+public struct Result: Equatable, Hashable {
     public enum Category {
         case warning, error, message
     }

--- a/Sources/DangerXCodeSummary/XCodeSummary.swift
+++ b/Sources/DangerXCodeSummary/XCodeSummary.swift
@@ -100,7 +100,7 @@ public final class XCodeSummary {
     
     /// Shows all build errors, warnings and unit tests results generated from `xcodebuild` or `Swift Package Manager`
     public func report() {
-        warnings.filter(using: resultsFilter).forEach {
+        warnings.filter(using: resultsFilter).removingDuplicates().forEach {
             if let file = $0.file,
                 let line = $0.line {
                 dsl.warn(message: $0.message, file: file, line: line)
@@ -109,7 +109,7 @@ public final class XCodeSummary {
             }
         }
         
-        errors.filter(using: resultsFilter).forEach {
+        errors.filter(using: resultsFilter).removingDuplicates().forEach {
             if let file = $0.file,
                 let line = $0.line {
                 dsl.fail(message: $0.message, file: file, line: line)
@@ -118,7 +118,7 @@ public final class XCodeSummary {
             }
         }
         
-        messages.filter(using: resultsFilter).forEach { dsl.message($0.message) }
+        messages.filter(using: resultsFilter).removingDuplicates().forEach { dsl.message($0.message) }
     }
 }
 
@@ -132,5 +132,13 @@ extension Array where Element == Result {
     func filter(using resultsFilter: ResultsFilter?) -> [Element] {
         guard let resultsFilter = resultsFilter else { return self }
         return self.filter(resultsFilter)
+    }
+
+    func removingDuplicates() -> [Element] {
+        var addedDict = [Element: Bool]()
+
+        return filter {
+            addedDict.updateValue(true, forKey: $0) == nil
+        }
     }
 }

--- a/Tests/DangerXCodeSummaryTests/Fixtures/DuplicatesJSON.swift
+++ b/Tests/DangerXCodeSummaryTests/Fixtures/DuplicatesJSON.swift
@@ -1,0 +1,48 @@
+let duplicatesJSON = """
+{
+  "warnings": [
+
+  ],
+  "ld_warnings": [
+    
+  ],
+  "compile_warnings": [
+    {
+        "file_name": "XCodeSummary.swift",
+        "file_path": "/Users/franco/Projects/DangerXCodeSummary/Sources/DangerXCodeSummary/XCodeSummary.swift:26:18",
+        "reason": "Test",
+        "line": "        #warning(\\"Test\\")",
+        "cursor": "                 ^~~~~~"
+    },
+    {
+        "file_name": "XCodeSummary.swift",
+        "file_path": "/Users/franco/Projects/DangerXCodeSummary/Sources/DangerXCodeSummary/XCodeSummary.swift:26:18",
+        "reason": "Test",
+        "line": "        #warning(\\"Test\\")",
+        "cursor": "                 ^~~~~~"
+    }
+  ],
+  "errors": [
+    "error: Build input file cannot be found: '/Users/franco/Projects/DangerXCodeSummary/Test.swift'",
+    "error: Build input file cannot be found: '/Users/franco/Projects/DangerXCodeSummary/Test.swift'"
+  ],
+  "compile_errors": [
+
+  ],
+  "file_missing_errors": [
+
+  ],
+  "undefined_symbols_errors": [
+
+  ],
+  "duplicate_symbols_errors": [
+
+  ],
+  "tests_failures": {
+  },
+  "tests_summary_messages": [
+    "\\t Executed 3 tests, with 0 failures (0 unexpected) in 0.039 (0.055) seconds\\n",
+    "\\t Executed 3 tests, with 0 failures (0 unexpected) in 0.039 (0.055) seconds\\n"
+  ]
+}
+"""

--- a/Tests/DangerXCodeSummaryTests/XCodeSummaryTests.swift
+++ b/Tests/DangerXCodeSummaryTests/XCodeSummaryTests.swift
@@ -110,4 +110,14 @@ final class XCodeSummaryTests: XCTestCase {
 
         try? FileManager.default.removeItem(atPath: "dsl.json")
     }
+
+    func testItFiltersOutDuplicates() {
+        let summary = XCodeSummary(json: JSONFile.jsonObject(fromString: duplicatesJSON), dsl: dsl)
+        summary.report()
+        XCTAssertEqual(dsl.warnings.count, 1)
+        XCTAssertEqual(dsl.fails.count, 1)
+        XCTAssertEqual(dsl.messages.count, 1)
+
+        try? FileManager.default.removeItem(atPath: "dsl.json")
+    }
 }


### PR DESCRIPTION
After switching over to this Swift version of the Ruby GEM we found out that we had a lot of duplicate warnings:

![image](https://user-images.githubusercontent.com/4329185/72885677-aa097280-3d08-11ea-8f17-a79cbef836d7.png)

We first thought that this had to be fixed in the compiler but it turned out that this is fixed with the Ruby gem by using a `uniq`:
https://github.com/diogot/danger-xcode_summary/blob/master/lib/xcode_summary/plugin.rb#L173

They're doing this for errors, warnings, and messages. That made us realize that we had to fix this in the library itself.

Therefore, this PR, which filters duplicates.