### PR TITLE
Allow to pass the danger instance and the file path

### DIFF
--- a/Sources/DangerXCodeSummary/XCodeSummary.swift
+++ b/Sources/DangerXCodeSummary/XCodeSummary.swift
@@ -84,7 +84,7 @@ public final class XCodeSummary {
         self.resultsFilter = resultsFilter
     }
     
-    public convenience init(filePath: String, resultsFilter: ResultsFilter? = nil) {
+    public convenience init(filePath: String, dsl: DangerDSL = Danger(), resultsFilter: ResultsFilter? = nil) {
         guard let content = try? String(contentsOfFile: filePath),
             let data = content.data(using: .utf8) else {
             fatalError("Report not found")
@@ -95,7 +95,7 @@ public final class XCodeSummary {
             fatalError("Report file is not a valid json")
         }
         
-        self.init(json: json, dsl: Danger(), resultsFilter: resultsFilter)
+        self.init(json: json, dsl: dsl, resultsFilter: resultsFilter)
     }
     
     /// Shows all build errors, warnings and unit tests results generated from `xcodebuild` or `Swift Package Manager`


### PR DESCRIPTION
Allows the convenience API to maintain the same contract as the regular initialiser, but pass the JSON file instead of the stringified JSON object.

The regular initialiser has default values for the Danger instance as well as the result filter allowing you to pass either of those arguments or take the default value, while the convenience initialiser forces you to use a new instance of Danger if you want to specify the name of the xcpretty-fied Xcode build logs .json file.