### PR TITLE
Update README based on errors found on working with Xcode 11.4.x+/Swift 5.2 and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,12 @@ DangerXCodeSummary can be used with SPM (this repo uses it on the Linux CI), but
 To generate the report run:
 
 ```bash
-swift test | XCPRETTY_JSON_FILE_OUTPUT=result.json xcpretty -f `xcpretty-json-formatter`
+swift test 2>&1 | XCPRETTY_JSON_FILE_OUTPUT=xcpretty_xcode_summary.json xcpretty -f `xcpretty-json-formatter`
+2<&1
+
+[...]
+
+swift run danger-swift ci --fail-on-errors=true
 ```
 
 ## Send report to Danger

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ You can use a "full SPM" solution to install both `danger-swift` and `DangerXCod
 - Add to your `Package.swift`:
 
 ```swift
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
 let package = Package(
     ...
     products: [
@@ -26,12 +31,14 @@ let package = Package(
     ],
     dependencies: [
         ...
+        // Danger
+        .package(name: "danger-swift", url: "https://github.com/danger/swift.git", from: "3.0.0"), // dev
         // Danger Plugins
-        .package(url: "https://github.com/f-meloni/danger-swift-xcodesummary", from: "0.1.0") // dev
+        .package(name: "DangerXCodeSummary", url: "https://github.com/f-meloni/danger-swift-xcodesummary", from: "1.2.1"), // dev
         ...
     ],
     targets: [
-        .target(name: "DangerDependencies", dependencies: ["Danger", "DangerXCodeSummary"]), // dev
+        .target(name: "DangerDependencies", dependencies: ["danger-swift", "DangerXCodeSummary"]) // dev
         ...
     ]
 )


### PR DESCRIPTION
As mentioned in the comments in this test PR ( https://github.com/f-meloni/danger-swift-xcodesummary/pull/20 ), I was not seeing the errors being recorded in Xcode Summary as expected nor the build to fail if a unit test failed (all output, errors included, needed to be redirected and piped through xcpretty).

Also, I had some issues installing Danger and Danger Plugins such as this one without adapting the Package.swift as SwiftPM was suggesting (see list of changes).